### PR TITLE
環境設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,7 @@
 development:
   adapter: mysql2
   encoding: utf8
-  database: mooovi_development
+  database: mooovi2_development
   pool: 5
   username: root
   password:
@@ -23,7 +23,7 @@ development:
 test:
   adapter: mysql2
   encoding: utf8
-  database: mooovi_test
+  database: mooovi2_test
   pool: 5
   username: root
   password:


### PR DESCRIPTION
tech::camp管理のリポジトリよりmoooviをクローン、
自作のデータベースと名前が重複するため、データベースの名前を変更。